### PR TITLE
Push all image tags

### DIFF
--- a/.github/workflows/oereb-db.yml
+++ b/.github/workflows/oereb-db.yml
@@ -18,7 +18,7 @@ jobs:
           docker-compose -f docker-compose.test.yml build
           docker-compose -f docker-compose.test.yml run sut
       - name: Publish docker image
-        run: echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin && docker push $DOCKER_ACCOUNT/$DOCKER_REPO
+        run: echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin && docker push --all-tags $DOCKER_ACCOUNT/$DOCKER_REPO
         if: ${{ github.ref == 'refs/heads/master' }}
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}


### PR DESCRIPTION
Since Docker 20.10.0, docker push only pushes the latest tag if no tag is specified: https://docs.docker.com/engine/release-notes/#20100