### PR TITLE
Fix workflow after moving main branch from sogis-oereb/oereb-db

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Override version number for 2.0.x builds
+        run: |
+          echo "VERSION=2.0.$(( 100 + ${{ github.run_number }} ))" >> $GITHUB_ENV
+
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,8 +92,8 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9  # v1.10.0 (2021-10-22)
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
         if: ${{ (github.ref == 'refs/heads/main') && (github.event_name != 'pull_request') && !env.ACT }}
 
       # Unschön ist das zweite Builden der Images. Multiarch push manuell ist nicht so prickelnd und
@@ -107,4 +107,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           pull: true
           push: ${{ (github.ref == 'refs/heads/main') && (github.event_name != 'pull_request') && !env.ACT }}
-

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM sogis/gretl-runtime:latest
+FROM sogis/gretl:latest
 
 USER root
 


### PR DESCRIPTION
Die Erhöhung der Revision Number um 100 ist nötig, weil wir diesen Branch aus dem Repo sogis-oereb/oereb-wms hierher verschoben haben. ${{ github.run_number }} begann dadurch wieder neu bei 1, wodurch nun neue Images tiefere Revision Numbers als bereits bestehende Images erhalten würden.